### PR TITLE
Fixing bug that add extra key frames to the material animations

### DIFF
--- a/Editor/H3DtoUnityUtils.cs
+++ b/Editor/H3DtoUnityUtils.cs
@@ -90,6 +90,19 @@ namespace P3DS2U.Editor
             Tex2Rot,
         }
 
+        public struct AnimationCurveIndex
+        {
+            public AnimationCurveIndex(MatAnimationModifier modifier, string elementName)
+            {
+                Modifier = modifier;
+                ElementName = elementName;
+            }
+
+            public MatAnimationModifier Modifier { get; }
+
+            public string ElementName { get; }
+        }
+
         public static string MatModifierToShaderProp (MatAnimationModifier matAnimationModifier)
         {
             switch (matAnimationModifier) {
@@ -110,18 +123,20 @@ namespace P3DS2U.Editor
             }
         }
         
-        public static AnimationCurve GetOrAddCurve(Dictionary<MatAnimationModifier, AnimationCurve> curvesDict, MatAnimationModifier modifier)
+        public static AnimationCurve GetOrAddCurve(Dictionary<AnimationCurveIndex, AnimationCurve> curvesDict, MatAnimationModifier modifier, string elementName)
         {
+            AnimationCurveIndex key = new AnimationCurveIndex(modifier, elementName);
+
             if (modifier == MatAnimationModifier.Skipped) {
                 Debug.LogError ("Type of anim not supported!");
                 return null;
             }
             
-            if (curvesDict.ContainsKey (modifier)) {
-                return curvesDict[modifier];
+            if (curvesDict.ContainsKey (key)) {
+                return curvesDict[key];
             }
             var newCurve = new AnimationCurve();
-            curvesDict.Add (modifier, newCurve);
+            curvesDict.Add (key, newCurve);
             return newCurve;
         }
 

--- a/Editor/PokemonImporter.cs
+++ b/Editor/PokemonImporter.cs
@@ -412,7 +412,7 @@ namespace P3DS2U.Editor
                     fileCreated = true;
                 }
                 
-                var newCurves = new Dictionary<AnimationUtils.MatAnimationModifier, AnimationCurve> ();
+                var newCurves = new Dictionary<AnimationUtils.AnimationCurveIndex, AnimationCurve> ();
                 foreach (var animationElement in currentMatAnim.Elements) {
                     switch (animationElement.PrimitiveType) {
                         case H3DPrimitiveType.Vector2D:
@@ -428,15 +428,18 @@ namespace P3DS2U.Editor
                             switch (targetType) {
                                 case H3DTargetType.MaterialTexCoord0Trans:
                                     curveY = AnimationUtils.GetOrAddCurve (newCurves,
-                                        AnimationUtils.MatAnimationModifier.Tex0TranslateY);
+                                        AnimationUtils.MatAnimationModifier.Tex0TranslateY,
+                                        animationElement.Name);
                                     break;
                                 case H3DTargetType.MaterialTexCoord1Trans:
                                     curveY = AnimationUtils.GetOrAddCurve (newCurves,
-                                        AnimationUtils.MatAnimationModifier.Tex1TranslateY);
+                                        AnimationUtils.MatAnimationModifier.Tex1TranslateY,
+                                        animationElement.Name);
                                     break;
                                 case H3DTargetType.MaterialTexCoord2Trans:
                                     curveY = AnimationUtils.GetOrAddCurve (newCurves,
-                                        AnimationUtils.MatAnimationModifier.Tex2TranslateY);
+                                        AnimationUtils.MatAnimationModifier.Tex2TranslateY,
+                                        animationElement.Name);
                                     break;
                             }
 
@@ -444,15 +447,18 @@ namespace P3DS2U.Editor
                             switch (targetType) {
                                 case H3DTargetType.MaterialTexCoord0Trans:
                                     curveX = AnimationUtils.GetOrAddCurve (newCurves,
-                                        AnimationUtils.MatAnimationModifier.Tex0TranslateX);
+                                        AnimationUtils.MatAnimationModifier.Tex0TranslateX,
+                                        animationElement.Name);
                                     break;
                                 case H3DTargetType.MaterialTexCoord1Trans:
                                     curveX = AnimationUtils.GetOrAddCurve (newCurves,
-                                        AnimationUtils.MatAnimationModifier.Tex1TranslateX);
+                                        AnimationUtils.MatAnimationModifier.Tex1TranslateX,
+                                        animationElement.Name);
                                     break;
                                 case H3DTargetType.MaterialTexCoord2Trans:
                                     curveX = AnimationUtils.GetOrAddCurve (newCurves,
-                                        AnimationUtils.MatAnimationModifier.Tex2TranslateX);
+                                        AnimationUtils.MatAnimationModifier.Tex2TranslateX,
+                                        animationElement.Name);
                                     break;
                             }
 
@@ -528,7 +534,7 @@ namespace P3DS2U.Editor
                                     if (skm.sharedMaterial.name.Replace (" (Instance)", "") == animationElement.Name) {
                                         var cbp = AnimationUtility.CalculateTransformPath (skm.transform,
                                             modelTransform);
-                                        var shaderPropName = AnimationUtils.MatModifierToShaderProp (kvp.Key);
+                                        var shaderPropName = AnimationUtils.MatModifierToShaderProp (kvp.Key.Modifier);
                                         animationClip.SetCurve (cbp, typeof(SkinnedMeshRenderer),
                                             shaderPropName, kvp.Value);
                                     }


### PR DESCRIPTION
I found a bug that create extra weird keyframes to material animations.
Steps to reproduce:
- Import Pikachu -> Check animation Fight_no_touch_attack
- Import Chikorita-> Check animation Fight_be_attacked
- Import Chansey-> Check animation Fight_be_attacked

The bug occurs because the texture animation keyframes are grouped by the TextureModifier, instead of the TextureModifier + ElementName combo, and this generate extra frames for non related elements, generating this weird behavior.

I changed the code to index this animation cuvers by the TextureModifier + ElementName combo.
